### PR TITLE
fix issue with adding and removing services from channel

### DIFF
--- a/src/main/java/tigerworkshop/webapphardwarebridge/BridgeWebSocketServer.java
+++ b/src/main/java/tigerworkshop/webapphardwarebridge/BridgeWebSocketServer.java
@@ -204,7 +204,7 @@ public class BridgeWebSocketServer extends WebSocketServer implements WebSocketS
         serviceList.add(service);
         serviceChannelSubscriptions.put(channel, serviceList);
 
-        if (!services.contains(services)) {
+        if (!services.contains(service)) {
             services.add(service);
         }
     }
@@ -214,9 +214,7 @@ public class BridgeWebSocketServer extends WebSocketServer implements WebSocketS
         serviceList.remove(service);
         serviceChannelSubscriptions.put(channel, serviceList);
 
-        if (services.contains(services)) {
-            services.remove(service);
-        }
+        services.remove(service);
     }
 
 }


### PR DESCRIPTION
# Issue
There has been an issue with adding and removing services from the list of services in BridgeWebSocketServer. Before adding a new service to the list, the idea seemed to be to check whether this service is already in the list. But the original code just checked whether the list of services contains the list of services (aka whether the list contains itself as element) which of course never happened. Before removing a service, the inverted check but with the same issue was performed.

# Solution
Now the code is checking whether the new service is already in the list. While removing a deleted service from the list, the check is unnecessary, because if the service is not the list, the list will be unchanged (default behavior of the remove-function).