### PR TITLE
Replace deprecated gradle syntax

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,32 +16,32 @@ allprojects {
 
     dependencies {
         // The production code uses the SLF4J logging API at compile time
-        compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.2'
-        compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.2'
-        compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.11.2'
+        implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.2'
+        implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.2'
+        implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.11.2'
 
-        compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.7'
+        implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.7'
 
-        compile group: 'commons-io', name: 'commons-io', version: '2.6'
+        implementation group: 'commons-io', name: 'commons-io', version: '2.6'
 
-        compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.8.1'
+        implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.8.1'
 
-        compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
+        implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
 
-        compile group: 'com.google.guava', name: 'guava', version: '28.0-jre'
+        implementation group: 'com.google.guava', name: 'guava', version: '28.0-jre'
 
-        compile group: 'com.fazecast', name: 'jSerialComm', version: '2.4.2'
+        implementation group: 'com.fazecast', name: 'jSerialComm', version: '2.4.2'
 
-        compile group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.14'
+        implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.14'
 
-        compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.62'
+        implementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.62'
 
-        compile group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.62'
+        implementation group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.62'
 
-        compile group: 'de.huxhorn.lilith', name: 'de.huxhorn.lilith.3rdparty.junique', version: '1.0.4'
+        implementation group: 'de.huxhorn.lilith', name: 'de.huxhorn.lilith.3rdparty.junique', version: '1.0.4'
 
-        compile group: 'org.java-websocket', name: 'Java-WebSocket', version: '1.4.0'
+        implementation group: 'org.java-websocket', name: 'Java-WebSocket', version: '1.4.0'
 
-        testCompile group: 'junit', name: 'junit', version: '4.12'
+        testImplementation group: 'junit', name: 'junit', version: '4.12'
     }
 }


### PR DESCRIPTION
## Issue
The `compile` and `testCompile` keywords were eliminated from gradle and were replaced with `implementation` and `testImplementation`. The current `build.gradle` contains the deprecated keywords. Due to the deprecation gradle cannot process the `build.gradle` and exits with error messages, e.g.:
```
A problem occurred evaluating root project 'webapp-hardware-bridge'.
> Could not find method compile() for arguments [{group=org.apache.logging.log4j, name=log4j-api, version=2.11.2}] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
```

## Solution
Replace `compile` with `implementation` and `testCompile` with `testImplementation`
 