### PR TITLE
Set correct reference to compiled output

### DIFF
--- a/.idea/artifacts/webapp_hardware_bridge_jar.xml
+++ b/.idea/artifacts/webapp_hardware_bridge_jar.xml
@@ -3,7 +3,7 @@
     <output-path>$PROJECT_DIR$/out/artifacts/webapp_hardware_bridge_jar</output-path>
     <root id="root">
       <element id="archive" name="webapp-hardware-bridge.jar">
-        <element id="module-output" name="webapp-hardware-bridge_main" />
+        <element id="module-output" name="webapp-hardware-bridge.main" />
         <element id="directory" name="META-INF">
           <element id="file-copy" path="$PROJECT_DIR$/src/main/java/META-INF/MANIFEST.MF" />
         </element>


### PR DESCRIPTION
## Issue
When building artifact for generating .jar file, the compiled output (i.e. class files) aren't placed in the archive. This is due to a error / typo in the artifact configuration.

## Solution
Reference module output of `webapp-hardware-bridge.main` instead of `webapp-hardware-bridge_main`.
