### PR TITLE
Automatically add new requested print type to the list and wait for selection

### DIFF
--- a/setting.default.json
+++ b/setting.default.json
@@ -5,6 +5,7 @@
   "fallbackToDefaultPrinter": false,
   "autoRotate": false,
   "resetImageableArea": true,
+  "addUnknownPrintTypeToList": true,
   "printerDPI": 0,
   "downloadTimeout": 30.0,
   "authentication": {

--- a/src/main/java/tigerworkshop/webapphardwarebridge/BridgeWebSocketServer.java
+++ b/src/main/java/tigerworkshop/webapphardwarebridge/BridgeWebSocketServer.java
@@ -108,8 +108,10 @@ public class BridgeWebSocketServer extends WebSocketServer implements WebSocketS
             socket.close();
         }
 
-        for (WebSocketServiceInterface service : services) {
-            service.stop();
+        synchronized (this) {
+            for(int i=0; i< services.size(); i++) {
+                services.get(i).stop();
+            }
         }
     }
 

--- a/src/main/java/tigerworkshop/webapphardwarebridge/controller/SettingController.java
+++ b/src/main/java/tigerworkshop/webapphardwarebridge/controller/SettingController.java
@@ -29,10 +29,7 @@ import java.awt.print.PrinterJob;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.ResourceBundle;
+import java.util.*;
 
 @SuppressWarnings("Duplicates")
 public class SettingController implements Initializable {
@@ -267,6 +264,8 @@ public class SettingController implements Initializable {
         });
 
         loadValues();
+
+        Setting.registerNewPrintTypeObserver(this);
     }
 
     private void loadCurrentValues() {
@@ -403,5 +402,23 @@ public class SettingController implements Initializable {
         setting.setSerials(serialHashMap);
 
         settingService.save();
+    }
+
+    /**
+     * Add a new printType to the list when window is open
+     *
+     * @param type the printType
+     * @param printerPlaceHolder a place holder
+     */
+    public void newPrintType(String type, String printerPlaceHolder) {
+
+        Optional<ObservableStringPair> isAlreadyInTheList =
+                printerMappingList.stream()
+                        .filter(x -> x.getLeft().equalsIgnoreCase(type))
+                        .findAny();
+
+        if(!isAlreadyInTheList.isPresent()) {
+            printerMappingList.add(new ObservableStringPair(type, printerPlaceHolder));
+        }
     }
 }

--- a/src/main/java/tigerworkshop/webapphardwarebridge/responses/Setting.java
+++ b/src/main/java/tigerworkshop/webapphardwarebridge/responses/Setting.java
@@ -1,5 +1,8 @@
 package tigerworkshop.webapphardwarebridge.responses;
 
+import tigerworkshop.webapphardwarebridge.controller.SettingController;
+
+import java.util.ArrayList;
 import java.util.HashMap;
 
 public class Setting {
@@ -10,8 +13,10 @@ public class Setting {
     boolean ignoreTLSCertificateError = false;
     boolean autoRotation = false;
     boolean resetImageableArea = true;
+    boolean addUnknownPrintTypeToList = true;
     int printerDPI = 0;
     Double downloadTimeout = 30.0;
+    private static ArrayList<SettingController> newPrintTypeObservers = new ArrayList<>();
 
     HashMap<String, Object> authentication = new HashMap<String, Object>() {{
         put("enabled", false);
@@ -205,5 +210,19 @@ public class Setting {
 
     public String getUri() {
         return (getTLSEnabled() ? "wss" : "ws") + "://" + getAddress() + ":" + getPort();
+    }
+
+    public boolean isAddUnknownPrintTypeToListEnabed() {
+        return addUnknownPrintTypeToList;
+    }
+
+    public static void registerNewPrintTypeObserver(SettingController listener) {
+        newPrintTypeObservers.add(listener);
+    }
+
+    public static void notifyNewPrintType(String type, String printerPlaceHolder) {
+        for(SettingController registeredObserver : newPrintTypeObservers) {
+            registeredObserver.newPrintType(type, printerPlaceHolder);
+        }
     }
 }

--- a/src/main/java/tigerworkshop/webapphardwarebridge/services/SettingService.java
+++ b/src/main/java/tigerworkshop/webapphardwarebridge/services/SettingService.java
@@ -68,4 +68,11 @@ public class SettingService {
             System.exit(1);
         }
     }
+
+    public void addPrintTypeToList(String printType) {
+        String PRINTER_PLACEHOLDER = "<select a printer>";
+        setting.getPrinters().put(printType, PRINTER_PLACEHOLDER);
+        Setting.notifyNewPrintType(printType, PRINTER_PLACEHOLDER);
+        save();
+    }
 }

--- a/src/main/java/tigerworkshop/webapphardwarebridge/websocketservices/PrinterWebSocketService.java
+++ b/src/main/java/tigerworkshop/webapphardwarebridge/websocketservices/PrinterWebSocketService.java
@@ -300,6 +300,10 @@ public class PrinterWebSocketService implements WebSocketServiceInterface {
             }
         }
 
+        if(settingService.getSetting().isAddUnknownPrintTypeToListEnabed()) {
+            settingService.addPrintTypeToList(type);
+        }
+
         if (settingService.getSetting().getFallbackToDefaultPrinter()) {
             logger.info("No mapped print job type: " + type + ", falling back to default printer");
             return PrintServiceLookup.lookupDefaultPrintService().createPrintJob();


### PR DESCRIPTION
New feature - make user life easier when a different/new print type is requested to the app, add automatically to the printing map list (enabled by default, can be disabled in the setting.json)

![image](https://user-images.githubusercontent.com/5892364/145657945-2561a4bc-b75c-435b-825e-e08c8c07daa9.png)
