### PR TITLE
Fix printing the same document when submitting two documents with the same name at (almost) the same time

### DIFF
--- a/src/main/java/tigerworkshop/webapphardwarebridge/responses/PrintDocument.java
+++ b/src/main/java/tigerworkshop/webapphardwarebridge/responses/PrintDocument.java
@@ -3,8 +3,10 @@ package tigerworkshop.webapphardwarebridge.responses;
 import tigerworkshop.webapphardwarebridge.utils.AnnotatedPrintable;
 
 import java.util.ArrayList;
+import java.util.UUID;
 
 public class PrintDocument {
+    private final UUID uuid;
     String type;
     String url;
     String id;
@@ -12,6 +14,14 @@ public class PrintDocument {
     String file_content;
     String raw_content;
     ArrayList<AnnotatedPrintable.AnnotatedPrintableAnnotation> extras = new ArrayList<>();
+
+    public PrintDocument() {
+        uuid = UUID.randomUUID();
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
 
     public String getType() {
         return type;
@@ -44,7 +54,8 @@ public class PrintDocument {
     @Override
     public String toString() {
         return "PrintDocument{" +
-                "type='" + type + '\'' +
+                "uuid='" + uuid + '\'' +
+                ", type='" + type + '\'' +
                 ", url='" + url + '\'' +
                 ", id='" + id + '\'' +
                 ", qty=" + qty +

--- a/src/main/java/tigerworkshop/webapphardwarebridge/services/DocumentService.java
+++ b/src/main/java/tigerworkshop/webapphardwarebridge/services/DocumentService.java
@@ -1,5 +1,6 @@
 package tigerworkshop.webapphardwarebridge.services;
 
+import org.apache.commons.io.FileUtils;
 import org.bouncycastle.util.encoders.Base64;
 import org.slf4j.LoggerFactory;
 import tigerworkshop.webapphardwarebridge.Config;
@@ -7,8 +8,11 @@ import tigerworkshop.webapphardwarebridge.responses.PrintDocument;
 import tigerworkshop.webapphardwarebridge.utils.DownloadUtil;
 
 import java.io.File;
-import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class DocumentService {
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DocumentService.class.getName());
@@ -18,7 +22,10 @@ public class DocumentService {
     private DocumentService() {
         File directory = new File(Config.DOCUMENT_PATH);
         if (!directory.exists()) {
-            directory.mkdir();
+            boolean result = directory.mkdir();
+            if (!result) {
+                logger.error("Directory for documents doesn't exist and can't be created.");
+            }
         }
     }
 
@@ -26,30 +33,35 @@ public class DocumentService {
         return instance;
     }
 
-    public static void extract(String base64, String urlString) throws Exception {
+    public static void extract(String base64, String uuid, String urlString) throws Exception {
         byte[] bytes = Base64.decode(base64);
 
-        try (OutputStream stream = new FileOutputStream(getPathFromUrl(urlString))) {
+        Path filePath = getPathFromUrl(uuid, urlString);
+        Files.createDirectories(filePath.getParent());
+        try (OutputStream stream = Files.newOutputStream(filePath)) {
             stream.write(bytes);
         }
     }
 
-    public static void download(String urlString) throws Exception {
-        DownloadUtil.file(urlString, getPathFromUrl(urlString), true, settingService.getSetting().getIgnoreTLSCertificateErrorEnabled(), settingService.getSetting().getDownloadTimeout());
+    public static void download(String uuid, String urlString) throws Exception {
+        Path filePath = getPathFromUrl(uuid, urlString);
+        Files.createDirectories(filePath.getParent());
+        DownloadUtil.file(urlString, filePath, settingService.getSetting().getIgnoreTLSCertificateErrorEnabled(), settingService.getSetting().getDownloadTimeout());
     }
 
-    public static File getFileFromUrl(String urlString) {
-        return new File(getPathFromUrl(urlString));
+    public static void deleteFileFromUrl(String uuid, String urlString) {
+        Path filePath = getPathFromUrl(uuid, urlString);
+        try {
+            FileUtils.deleteDirectory(filePath.getParent().toFile());
+        } catch (IOException e) {
+            logger.error("Couldn't delete downloaded document.");
+        }
     }
 
-    public static void deleteFileFromUrl(String urlString) {
-        getFileFromUrl(urlString).delete();
-    }
-
-    public static String getPathFromUrl(String urlString) {
+    public static Path getPathFromUrl(String uuid, String urlString) {
         urlString = urlString.replace(" ", "%20");
         String filename = urlString.substring(urlString.lastIndexOf("/") + 1);
-        return Config.DOCUMENT_PATH + filename;
+        return Paths.get(Config.DOCUMENT_PATH + uuid + "/" + filename);
     }
 
     public void prepareDocument(PrintDocument printDocument) throws Exception {
@@ -62,9 +74,9 @@ public class DocumentService {
         }
 
         if (printDocument.getFileContent() != null) {
-            extract(printDocument.getFileContent(), printDocument.getUrl());
+            extract(printDocument.getFileContent(), printDocument.getUuid().toString(), printDocument.getUrl());
         } else {
-            download(printDocument.getUrl());
+            download(printDocument.getUuid().toString(), printDocument.getUrl());
         }
     }
 }

--- a/src/main/java/tigerworkshop/webapphardwarebridge/utils/DownloadUtil.java
+++ b/src/main/java/tigerworkshop/webapphardwarebridge/utils/DownloadUtil.java
@@ -12,27 +12,21 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.cert.X509Certificate;
 
 public class DownloadUtil {
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DownloadUtil.class.getName());
 
-    public static long file(String urlString, String path, Boolean overwrite, Boolean ignoreCertError, double downloadTimeout) throws Exception {
+    public static long file(String urlString, Path path, Boolean ignoreCertError, double downloadTimeout) throws Exception {
         logger.info("Downloading file from: " + urlString);
         long timeStart = System.currentTimeMillis();
 
-        urlString.replace(" ", "%20");
+        urlString = urlString.replace(" ", "%20");
 
-        File outputFile = new File(path);
         try {
-            // File Exist, return
-            if (!overwrite && outputFile.exists()) {
-                long timeFinish = System.currentTimeMillis();
-                logger.info("File " + path + " found on local disk in " + (timeFinish - timeStart) + "ms");
-                return timeStart;
-            }
-
-            // Otherwise download it
+            // Download it
             URL url = new URL(urlString);
 
             if (ignoreCertError) {
@@ -77,7 +71,7 @@ public class DownloadUtil {
                 throw new IOException("HTTP Status Code: " + responseCode);
             }
 
-            FileUtils.copyInputStreamToFile(urlConnection.getInputStream(), outputFile);
+            FileUtils.copyInputStreamToFile(urlConnection.getInputStream(), path.toFile());
 
             long timeFinish = System.currentTimeMillis();
             logger.info("File " + path + " downloaded in " + (timeFinish - timeStart) + "ms");

--- a/src/main/java/tigerworkshop/webapphardwarebridge/websocketservices/PrinterWebSocketService.java
+++ b/src/main/java/tigerworkshop/webapphardwarebridge/websocketservices/PrinterWebSocketService.java
@@ -99,7 +99,7 @@ public class PrinterWebSocketService implements WebSocketServiceInterface {
             server.onDataReceived(getChannel(), gson.toJson(new PrintResult(0, printDocument.getId(), "Success")));
         } catch (Exception e) {
             logger.error("Document Print Error, deleting downloaded document");
-            DocumentService.deleteFileFromUrl(printDocument.getUrl());
+            DocumentService.deleteFileFromUrl(printDocument.getUuid().toString(), printDocument.getUrl());
 
             if (notificationListener != null) {
                 notificationListener.notify("Printing Error " + printDocument.getType(), e.getMessage(), TrayIcon.MessageType.ERROR);
@@ -169,7 +169,7 @@ public class PrinterWebSocketService implements WebSocketServiceInterface {
     private void printImage(PrintDocument printDocument) throws PrinterException, IOException {
         logger.debug("printImage::" + printDocument);
 
-        String filename = DocumentService.getFileFromUrl(printDocument.getUrl()).getPath();
+        String filename = DocumentService.getPathFromUrl(printDocument.getUuid().toString(), printDocument.getUrl()).toString();
 
         long timeStart = System.currentTimeMillis();
 
@@ -205,7 +205,7 @@ public class PrinterWebSocketService implements WebSocketServiceInterface {
     private void printPDF(PrintDocument printDocument) throws PrinterException, IOException {
         logger.debug("printPDF::" + printDocument);
 
-        String filename = DocumentService.getFileFromUrl(printDocument.getUrl()).getPath();
+        String filename = DocumentService.getPathFromUrl(printDocument.getUuid().toString(), printDocument.getUrl()).toString();
 
         long timeStart = System.currentTimeMillis();
 


### PR DESCRIPTION
### Issue
When a document with the same name as a document, which has been submitted for printing recently, is submitted and before the previous document with the same name was printed, the new document overwrites the older document. This leads to the printing of the same (newer) document twice, while the older document has never been printed.

### Solution
Add document's UUID to the filepath.